### PR TITLE
Simplifying API.

### DIFF
--- a/app/components/debug/DebugFormikState.tsx
+++ b/app/components/debug/DebugFormikState.tsx
@@ -1,9 +1,10 @@
-import { useFormikState } from '@formik/reducer-refs';
+import { useFormikApi, useFullFormikState } from '@formik/reducer-refs';
 import React from 'react';
 import { DebugProps } from './DebugProps';
 
 export const DebugFormikState = () => {
-  const [formikState] = useFormikState();
+  const formikApi = useFormikApi();
+  const formikState = useFullFormikState(formikApi);
 
   return <DebugProps {...formikState} />;
 };

--- a/packages/@formik/reducer-refs/src/components/Field.tsx
+++ b/packages/@formik/reducer-refs/src/components/Field.tsx
@@ -10,7 +10,7 @@ import {
 import invariant from 'tiny-warning';
 import { FormikRefApi, useFormikApi } from '../hooks/useFormikApi';
 import { useField, UseFieldProps } from '../hooks/useField';
-import { useFormikRefStateInternal } from '../hooks/useFormikState';
+import { useFullFormikState } from '../hooks/useFullFormikState';
 
 export interface FieldProps<Value = any, FormValues = any> {
   field: FieldInputProps<Value>;
@@ -107,8 +107,9 @@ export function Field<FieldValue = any, FormValues = any>(
    *
    * Otherwise, we will pointlessly get the initial values but never subscribe to updates.
    */
-  const [formikState, formikApi] = useFormikRefStateInternal(
-    useFormikApi<FormValues>(),
+  const formikApi = useFormikApi<FormValues>();
+  const formikState = useFullFormikState(
+    formikApi,
     !!render || isFunction(children)
   );
 

--- a/packages/@formik/reducer-refs/src/components/Formik.tsx
+++ b/packages/@formik/reducer-refs/src/components/Formik.tsx
@@ -9,8 +9,8 @@ import {
 import invariant from 'tiny-warning';
 import { useFormik } from '../hooks/useFormik';
 import { FormikApiContext } from '../contexts/FormikApiContext';
-import { useFormikRefStateInternal } from '../hooks/useFormikState';
 import { FormikRefState } from '../types';
+import { useFullFormikState } from '../hooks/useFullFormikState';
 
 export function Formik<
   Values extends FormikValues = FormikValues,
@@ -21,8 +21,9 @@ export function Formik<
   // get state and add a form effect if render or child function is used
   // aka, we need to pass FormikState directly
   // also component, because it is documented that way
-  const [formikState, formikApi] = useFormikRefStateInternal(
-    useFormik<Values>(props),
+  const formikApi = useFormik<Values>(props);
+  const formikState = useFullFormikState(
+    formikApi,
     !!component || !!render || isFunction(children)
   );
 

--- a/packages/@formik/reducer-refs/src/contexts/FormikContext.tsx
+++ b/packages/@formik/reducer-refs/src/contexts/FormikContext.tsx
@@ -7,6 +7,9 @@ export const FormikContext = React.createContext<FormikContextType<any>>(
 );
 export const FormikProvider = FormikContext.Provider;
 
+/**
+ * @deprecated Using a full Formik Context is deprecated. Please access bits of Formik state via useFormikState() or micro-hooks.
+ */
 export function FormikConsumer<Values = any>({
   children,
 }: {

--- a/packages/@formik/reducer-refs/src/helpers/subscription-helpers.ts
+++ b/packages/@formik/reducer-refs/src/helpers/subscription-helpers.ts
@@ -38,12 +38,12 @@ export const selectGetSelector = <State>(): GetSelectorFn<State> => <
 export type Comparer<Return> = (prev: Return, next: Return) => boolean;
 
 export type Subscriber<State, Args extends any[], Return> = {
-  selector: SliceFn<State, Return> | Selector<State, Args, Return>;
+  selector: Selector<State, Args, Return> | SliceFn<State, Return>;
   comparer: Comparer<Return>;
 };
 
 export type CreateSubscriberFn<State> = <Args extends any[], Return>(
-  selector: SliceFn<State, Return> | Selector<State, Args, Return>,
+  selector: Selector<State, Args, Return> | SliceFn<State, Return>,
   comparer: Comparer<Return>
 ) => Subscriber<State, Args, Return>;
 

--- a/packages/@formik/reducer-refs/src/hooks/useFormikComputedState.ts
+++ b/packages/@formik/reducer-refs/src/hooks/useFormikComputedState.ts
@@ -1,9 +1,9 @@
-import { FormikValues, FormikComputedState } from '@formik/core';
+import { FormikComputedState } from '@formik/core';
 import { useMemo } from 'react';
-import { FormikRefApi, useFormikApi } from './useFormikApi';
+import { FormikRefApi } from './useFormikApi';
 import { FormikRefState } from '../types';
-import { useFormikStateSubscription } from './useFormikStateSubscription';
 import { isEqual } from 'lodash';
+import { useFormikState } from './useFormikState';
 
 /**
  * `useFormikState`, but accepting `FormikApi` as a parameter.
@@ -11,9 +11,9 @@ import { isEqual } from 'lodash';
  * @param api FormikApi instance returned by `useFormik` or `useFormikApi`
  * @param shouldAddFormEffect whether to continue listening for FormikState changes
  */
-export const useFormikComputedStateInternal = <Values extends FormikValues>(
-  api: FormikRefApi<Values>,
-  state: Pick<FormikRefState<Values>, 'errors' | 'dirty'>
+export const useFormikComputedStateInternal = (
+  api: FormikRefApi<any>,
+  state: Pick<FormikRefState<any>, 'errors' | 'dirty'>
 ): FormikComputedState => {
   const { isFormValid } = api;
 
@@ -27,9 +27,7 @@ export const useFormikComputedStateInternal = <Values extends FormikValues>(
   };
 };
 
-const selectComputedState = <Values extends FormikValues>(
-  state: FormikRefState<Values>
-) => ({
+const selectComputedState = (state: FormikRefState<any>) => ({
   errors: state.errors,
   dirty: state.dirty,
 });
@@ -38,13 +36,5 @@ const selectComputedState = <Values extends FormikValues>(
  * Subscribe to Formik State and Computed State updates.
  */
 export const useFormikComputedState = () => {
-  const api = useFormikApi();
-  const subscriber = useMemo(
-    () => api.createSubscriber(selectComputedState, isEqual),
-    [api]
-  );
-  return useFormikComputedStateInternal(
-    api,
-    useFormikStateSubscription(subscriber)
-  );
+  return useFormikState(selectComputedState, isEqual);
 };

--- a/packages/@formik/reducer-refs/src/hooks/useFormikContext.ts
+++ b/packages/@formik/reducer-refs/src/hooks/useFormikContext.ts
@@ -1,7 +1,7 @@
 import invariant from 'tiny-warning';
 import { FormikContextType } from '@formik/core';
 import { useFormikApi } from './useFormikApi';
-import { useFormikRefStateInternal } from './useFormikState';
+import { useFullFormikState } from './useFullFormikState';
 
 /**
  * @deprecated Formik is no longer exposing its state as Context. Please use `useFormikStateSlice(state => { errors: state.errors })` for a slice of state, or `useFormikState()` for the whole thing (at the expense of performance)
@@ -14,7 +14,7 @@ export function useFormikContext<Values>(): FormikContextType<Values> {
     `Formik API context is undefined, please verify you are calling useFormikContext() as child of a <Formik> component.`
   );
 
-  const [formikState] = useFormikRefStateInternal(formikApi);
+  const formikState = useFullFormikState<Values>(formikApi);
 
   return {
     ...formikApi,

--- a/packages/@formik/reducer-refs/src/hooks/useFormikState.ts
+++ b/packages/@formik/reducer-refs/src/hooks/useFormikState.ts
@@ -1,60 +1,78 @@
-import { useFormikComputedStateInternal } from './useFormikComputedState';
+import { useFormikStateSubscriptionInternal } from './useFormikStateSubscription';
 import {
-  FormikValues,
-  FormikComputedState,
-  useIsomorphicLayoutEffect,
-} from '@formik/core';
-import { useMemo, useState } from 'react';
+  Comparer,
+  SelectorFn,
+  SliceFn,
+  Subscriber,
+} from './../helpers/subscription-helpers';
+import { isFunction } from '@formik/core';
+import { useMemo } from 'react';
 import { FormikRefApi, useFormikApi } from './useFormikApi';
 import { FormikRefState } from '../types';
 
-export const selectFullState = <State>(state: State) => state;
+export type UseFormikStateFn<Values> = <Args extends any[], Return>(
+  selector:
+    | [SelectorFn<FormikRefState<Values>, Args, Return>, ...Args]
+    | SliceFn<FormikRefState<Values>, Return>,
+  comparer?: Comparer<Return>,
+  shouldSubscribe?: boolean
+) => Return;
 
 /**
  * `useFormikState`, but accepting `FormikApi` as a parameter.
  *
  * @param api FormikApi instance returned by `useFormik` or `useFormikApi`
- * @param shouldAddFormEffect whether to continue listening for FormikState changes
  */
-export const useFormikRefStateInternal = <Values extends FormikValues>(
+export const useFormikStateInternal = <Values, Args extends any[], Return>(
   api: FormikRefApi<Values>,
-  shouldAddFormEffect = true
-): [FormikRefState<Values> & FormikComputedState, FormikRefApi<Values>] => {
-  const { getState, createSubscriber } = api;
-  const [formikState, setFormikState] = useState(getState());
-  const computedState = useFormikComputedStateInternal(api, formikState);
-  const subscriber = useMemo(
-    () =>
-      createSubscriber<[], FormikRefState<Values>>(selectFullState, Object.is),
-    [createSubscriber]
-  );
+  selector:
+    | [SelectorFn<FormikRefState<Values>, Args, Return>, ...Args]
+    | SliceFn<FormikRefState<Values>, Return>,
+  comparer: Comparer<Return> = Object.is,
+  shouldSubscribe = true
+) => {
+  const { createSelector, createSubscriber } = api;
 
-  useIsomorphicLayoutEffect(() => {
-    // in case someone accidentally passes `undefined`
-    if (shouldAddFormEffect !== false) {
-      // not deep equals, because those are expensive checks.
-      // instead, subscribing to full useFormikState should be discouraged
-      return api.subscribe(subscriber, setFormikState);
+  const subscriber: Subscriber<
+    FormikRefState<Values>,
+    Args,
+    Return
+  > = useMemo(() => {
+    if (isFunction(selector)) {
+      return createSubscriber(selector, comparer);
+    } else {
+      const [selectorFn, ...args] = selector;
+      return createSubscriber(createSelector(selectorFn, args), comparer);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    comparer,
+    createSelector,
+    createSubscriber,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    ...(isFunction(selector) ? [selector] : selector),
+  ]);
 
-    return;
-  }, [shouldAddFormEffect]);
-
-  return [
-    useMemo(
-      () => ({
-        ...formikState,
-        ...computedState,
-      }),
-      [formikState, computedState]
-    ),
+  return useFormikStateSubscriptionInternal<Values, Args, Return>(
     api,
-  ];
+    subscriber,
+    shouldSubscribe
+  );
 };
 
 /**
  * Subscribe to Formik State and Computed State updates.
  */
-export const useFormikState = <Values extends FormikValues>() => {
-  return useFormikRefStateInternal(useFormikApi<Values>());
+export const useFormikState = <Values, Args extends any[], Return>(
+  selector:
+    | [SelectorFn<FormikRefState<Values>, Args, Return>, ...Args]
+    | SliceFn<FormikRefState<Values>, Return>,
+  comparer: Comparer<Return> = Object.is,
+  shouldSubscribe = true
+): [Return, FormikRefApi<Values>] => {
+  const api = useFormikApi<Values>();
+  return [
+    useFormikStateInternal(api, selector, comparer, shouldSubscribe),
+    api,
+  ];
 };

--- a/packages/@formik/reducer-refs/src/hooks/useFormikStateSubscription.tsx
+++ b/packages/@formik/reducer-refs/src/hooks/useFormikStateSubscription.tsx
@@ -2,7 +2,7 @@ import { FormikValues, useIsomorphicLayoutEffect } from '@formik/core';
 import React from 'react';
 import { Subscriber } from '../helpers/subscription-helpers';
 import { FormikRefState } from '../types';
-import { useFormikApi } from './useFormikApi';
+import { FormikRefApi } from './useFormikApi';
 
 export type FormSliceFn<Values, Result> = (
   formState: FormikRefState<Values>
@@ -11,21 +11,27 @@ export type FormSliceFn<Values, Result> = (
 /**
  * Important! Use a stable or memoized subscriber.
  */
-export const useFormikStateSubscription = <
+export const useFormikStateSubscriptionInternal = <
   Values extends FormikValues,
   Args extends any[],
   Return
 >(
-  subscriber: Subscriber<FormikRefState<Values>, Args, Return>
+  api: FormikRefApi<Values>,
+  subscriber: Subscriber<FormikRefState<Values>, Args, Return>,
+  shouldSubscribe = true
 ) => {
-  const { subscribe, getState, getSelector } = useFormikApi<Values>();
+  const { subscribe, getState, getSelector } = api;
   const [sliceState, setSliceState] = React.useState(() =>
     getSelector(subscriber.selector)(getState())
   );
 
   useIsomorphicLayoutEffect(() => {
-    return subscribe(subscriber, setSliceState);
-  }, [subscribe, subscriber]);
+    if (shouldSubscribe) {
+      return subscribe(subscriber, setSliceState);
+    }
+
+    return;
+  }, [subscribe, subscriber, shouldSubscribe]);
 
   return sliceState;
 };

--- a/packages/@formik/reducer-refs/src/hooks/useFullFormikState.ts
+++ b/packages/@formik/reducer-refs/src/hooks/useFullFormikState.ts
@@ -1,0 +1,32 @@
+import { useFormikComputedStateInternal } from './useFormikComputedState';
+import { useMemo } from 'react';
+import { FormikRefApi } from './useFormikApi';
+import { FormikRefState } from '../types';
+import { useFormikStateInternal } from './useFormikState';
+
+export type SelectFullStateFn<Values> = (
+  state: FormikRefState<Values>
+) => FormikRefState<Values>;
+
+export const selectFullState: SelectFullStateFn<unknown> = state => state;
+
+export const useFullFormikState = <Values>(
+  api: FormikRefApi<Values>,
+  shouldSubscribe = true
+) => {
+  const state = useFormikStateInternal(
+    api,
+    selectFullState as SelectFullStateFn<Values>,
+    Object.is,
+    shouldSubscribe
+  );
+  const computedState = useFormikComputedStateInternal(api, state);
+
+  return useMemo(
+    () => ({
+      ...state,
+      ...computedState,
+    }),
+    [state, computedState]
+  );
+};

--- a/packages/@formik/reducer-refs/src/index.tsx
+++ b/packages/@formik/reducer-refs/src/index.tsx
@@ -12,5 +12,6 @@ export * from './hooks/useFormik';
 export * from './hooks/useFormikApi';
 export * from './hooks/useFormikContext';
 export * from './hooks/useFormikState';
+export * from './hooks/useFullFormikState';
 export * from './withFormik';
 export * from './types';

--- a/packages/@formik/reducer-refs/test/Field.test.tsx
+++ b/packages/@formik/reducer-refs/test/Field.test.tsx
@@ -16,9 +16,10 @@ import {
   FieldConfig,
   FieldComponentProps,
   FastFieldConfig,
-  useFormikState,
   FormikRefApi,
   FormikRefState,
+  useFullFormikState,
+  useFormikApi,
 } from '../src';
 import { noop } from './testHelpers';
 import { FormikConfig, FormikProps } from '@formik/core';
@@ -134,7 +135,9 @@ describe('Field / FastField', () => {
       };
 
       const AsComponent = (props: FieldProps['field']) => {
-        [formikState, formikApi] = useFormikState();
+        formikApi = useFormikApi();
+        formikState = useFullFormikState(formikApi);
+
         asInjectedProps = props;
 
         return <div data-testid="child">{TEXT}</div>;

--- a/packages/@formik/reducer-refs/test/Formik.test.tsx
+++ b/packages/@formik/reducer-refs/test/Formik.test.tsx
@@ -6,7 +6,13 @@ import {
 import * as React from 'react';
 import { render, fireEvent, wait } from 'react-testing-library';
 import * as Yup from 'yup';
-import { Formik, FormikRefApi, FormikRefState, useFormikState } from '../src';
+import {
+  Formik,
+  FormikRefApi,
+  FormikRefState,
+  useFormikApi,
+  useFullFormikState,
+} from '../src';
 import { noop } from './testHelpers';
 
 jest.spyOn(global.console, 'warn');
@@ -60,7 +66,8 @@ function renderFormik<Values extends TestValues = TestValues>(
   let formikState: FormikRefState<Values> | undefined;
 
   const ContextRenderer = () => {
-    [formikState, formikApi] = useFormikState<Values>();
+    formikApi = useFormikApi();
+    formikState = useFullFormikState<Values>(formikApi);
     return null;
   };
 


### PR DESCRIPTION
Separate useFullFormikState into its own hook for reuse and separation of concerns.
Change the default formik state hook to `useFormikState(selector | [selector, ...args], comparer)` with auto-memoization.
Stop exposing the useFormikSubscription hook.
`useFormikState` is not quite auto-inferrable from TypeScript. :(