### PR TITLE
Upgrade to TS4 (tsdx still uses TS3.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "typescript": "^4.0.3"
   },
   "resolutions": {
+    "**/typescript": "^4.0.3",
     "@types/react": "^16.9.55"
   },
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -15446,12 +15446,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.3:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
-
-typescript@^4.0.3:
+typescript@^3.7.3, typescript@^4.0.3:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
   integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==


### PR DESCRIPTION
Need to resolve to TS 4.x to use Spread Operators in Tuples ( [Function, ...Args] ).